### PR TITLE
Add nested generators functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Version](https://img.shields.io/badge/gem-v0.1.1-blue.svg)](https://rubygems.org/gems/paradigm)
+[![Version](https://img.shields.io/badge/gem-v0.1.2-blue.svg)](https://rubygems.org/gems/paradigm)
 [![Rating ](https://img.shields.io/badge/rating-100%2F5-brightgreen.svg)](https://rubygems.org/gems/paradigm)
 
 # Paradigm: abstractions so good you'll cry
@@ -25,12 +25,21 @@ rails generate paradigm:install
 
 ### Services
 
+#### Top level services
+
 ```
 rails generate paradigm:service user_creation
 ```
 
-Sets up a `app/services` directory with a `user_creation_service.rb` file. Also adds a `user_creation_service_test.rb` file in your test directory.
+Sets up a `app/services` directory with a `user_creation_service.rb` file. Also adds a `user_creation_service_test.rb` file in the `test/services` directory.
 
+#### Nested services
+
+```
+rails generate paradigm:service account:user_creation
+```
+
+Sets up a `app/services/account` directory with a `user_creation_service.rb` file. Also adds a `user_creation_service_test.rb` file in the `test/services/account` directory.
 
 ## Copyright and Licenses
 

--- a/lib/generators/paradigm/service_generator.rb
+++ b/lib/generators/paradigm/service_generator.rb
@@ -6,8 +6,25 @@ module Paradigm
       source_root File.expand_path('../../templates/service', __FILE__)
 
       def create_service_file
-        template 'service.rb',      "app/services/#{file_name.underscore}_service.rb"
-        template 'service_test.rb', "test/services/#{file_name.underscore}_service_test.rb"
+        @file_name = file_name
+
+        if nested_file_name?
+          @path = file_name.partition(':').delete_if { |x| x == ':' }
+
+          template 'nested_service.rb', "app/services/#{path[0]}/#{path[1].underscore}_service.rb"
+          template 'nested_service_test.rb', "test/services/#{path[0]}/#{path[1].underscore}_service_test.rb"
+        else
+          template 'service.rb', "app/services/#{file_name.underscore}_service.rb"
+          template 'service_test.rb', "test/services/#{file_name.underscore}_service_test.rb"
+        end
+      end
+
+      private
+
+      attr_reader :file_name, :path
+
+      def nested_file_name?
+        file_name.include?(':')
       end
     end
   end

--- a/lib/generators/templates/service/nested_service.rb
+++ b/lib/generators/templates/service/nested_service.rb
@@ -1,0 +1,11 @@
+class <%= @path[0].camelcase %>::<%= @path[1].camelcase %>Service
+  include Service
+
+  def call
+    # add service logic here
+  end
+
+  private
+
+  # keep the #call method readable by extracting private methods
+end

--- a/lib/generators/templates/service/nested_service_test.rb
+++ b/lib/generators/templates/service/nested_service_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class <%= @path[0].camelcase %>::<%= @path[1].camelcase %>ServiceTest < ActiveSupport::TestCase
+  # test '.call' do
+  #   assert true
+  # end
+end

--- a/lib/paradigm/rails/version.rb
+++ b/lib/paradigm/rails/version.rb
@@ -1,5 +1,5 @@
 module Paradigm
   module Rails
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/test/generators/service_generator_test.rb
+++ b/test/generators/service_generator_test.rb
@@ -13,4 +13,11 @@ class ServiceGeneratorTest < Rails::Generators::TestCase
     assert_file 'app/services/send_user_email_service.rb', %r{SendUserEmailService}
     assert_file 'test/services/send_user_email_service_test.rb', %r{SendUserEmailServiceTest}
   end
+
+  test 'service template files can be nested' do
+    run_generator %w(account:send_user_email)
+
+    assert_file 'app/services/account/send_user_email_service.rb', %r{Account::SendUserEmailService}
+    assert_file 'test/services/account/send_user_email_service_test.rb', %r{Account::SendUserEmailServiceTest}
+  end
 end


### PR DESCRIPTION
This commit:

* Adds the ability to generate nested service files.

ex:

```
rails generate paradigm:service payment:send_refund
```

Will generate a `app/services/payment/send_refund_service.rb` file along with a similarly nested test file.